### PR TITLE
Improve peer connection management

### DIFF
--- a/network/ipfs_impl.go
+++ b/network/ipfs_impl.go
@@ -425,7 +425,7 @@ func (bsnet *impl) peerUpdatedSubscription(ctx context.Context, sub event.Subscr
 
 func (bsnet *impl) peerSupportsBitswap(peerID peer.ID) bool {
 	protocols, err := bsnet.host.Peerstore().SupportsProtocols(peerID, protocol.ConvertToStrings(bsnet.supportedProtocols)...)
-	return err != nil && len(protocols) > 0
+	return err == nil && len(protocols) > 0
 }
 
 func (bsnet *impl) hasBitswapProtocol(protos []protocol.ID) bool {


### PR DESCRIPTION
Currently, the bitswap network only adds peers to its client/server peer lists that connected after the network has started. This means the network must be started before enabling the libp2p listeners, otherwise some peers may connect too early and never be added to the network.

To address this, this PR updates the bitswap network's `Start()` method to first, listen for new peer connection events, and then iterate through all peers and add any that support the bitswap protocols. The issue and solution were originally described by @Stebalien in https://github.com/ipfs/go-libipfs/issues/83.